### PR TITLE
feat(schema): make the context type arg optional and add docs on its use

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ export interface UserDoc {
   name: string;
 }
 
-export class UserDataSource extends CosmosDataSource<UserDoc, ApolloContext> {}
-export class PostDataSource extends CosmosDataSource<PostDoc, ApolloContext> {}
+export class UserDataSource extends CosmosDataSource<UserDoc> {}
+export class PostDataSource extends CosmosDataSource<PostDoc> {}
 ```
 
 `server.ts`
@@ -43,6 +43,20 @@ const server = new ApolloServer({
     posts: new PostDataSource(cosmosContainer),
   }),
 });
+```
+
+## Context
+
+It is often useful to define a context. See [Apollo docs on context](https://www.apollographql.com/docs/apollo-server/data/context/) To make this strongly typed, there is a second type paramater on the CosmosDbDataSource:
+
+```typescript
+interface MyQueryContext {
+  currentUserId: string
+}
+
+/////
+
+const userDataSource extends CosmosDataSource<UserDoc, MyQueryContext> {}
 ```
 
 ## Custom Queries

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -7,6 +7,7 @@ import { Logger } from "./helpers";
 import { isCosmosDbContainer } from "./helpers";
 import { createCachingMethods, CachedMethods, FindArgs } from "./cache";
 
+
 export interface CosmosDataSourceOptions {
   logger?: Logger;
 }
@@ -24,7 +25,7 @@ export interface CosmosQueryDbArgs {
 
 export type QueryFindArgs = FindArgs & CosmosQueryDbArgs;
 
-export class CosmosDataSource<TData extends { id: string }, TContext>
+export class CosmosDataSource<TData extends { id: string }, TContext = null>
   extends DataSource<TContext>
   implements CachedMethods<TData> {
   container: Container;

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,3 +1,5 @@
+/* eslint @typescript-eslint/no-unused-vars: "off" */
+
 import { CosmosDataSource } from "../src/datasource";
 
 interface UserDoc {

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,0 +1,17 @@
+import { CosmosDataSource } from "../src/datasource";
+
+interface UserDoc {
+  id: string;
+  email: string;
+  partitionKey?: string;
+}
+
+interface Context {
+  something: string;
+}
+
+// normal context specified
+class UserDataSource1 extends CosmosDataSource<UserDoc, Context> {}
+
+// no context specified
+class UserDataSource2 extends CosmosDataSource<UserDoc> {}


### PR DESCRIPTION
address #73 

- make the Context type optional
- add README note on context
- add test for both variations of declaring a datasource