### PR TITLE
Feat: Add maxItemCount option for pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ const userPair = await users.findManyByIds([id1, id2], {ttl}) // => Promise<(T |
 await users.deleteFromCacheById(id}) // => Promise<void>
 
 // query method; note that this returns the CosmosDB FeedResponse object because sometimes this extra information is useful
-const userListResponse = await users.findManyByQuery('SELECT * from c where c.type="User"', {ttl, requestOptions}) // => Promise<FeedResponse<T>>
+const userListResponse = await users.findManyByQuery('SELECT * from c where c.type="User"', {ttl, requestOptions, maxItemCount}) // => Promise<FeedResponse<T>>
 console.log(userListResponse.resources) // user array from query
 
 // create method returns the CosmosDB ItemResponse object


### PR DESCRIPTION
Implements the maxItemCount option in findManyByQuery to allow users to control the number of items returned per page from Cosmos DB. 

This change:
- Adds `maxItemCount` as a direct option in `QueryFindArgs`.
- Updates `findManyByQuery` to use `iterator.fetchNext()` to respect pagination, instead of `fetchAll()`.
- Includes integration tests to verify `maxItemCount` functionality with the CosmosDB simulator.
- Updates README documentation.